### PR TITLE
Fixed event bubbling issue

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -90,7 +90,7 @@ export default class MultiSlider extends React.Component {
         onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
         onPanResponderGrant: (evt, gestureState) => start(),
         onPanResponderMove: (evt, gestureState) => move(gestureState),
-        onPanResponderTerminationRequest: (evt, gestureState) => true,
+        onPanResponderTerminationRequest: (evt, gestureState) => false,
         onPanResponderRelease: (evt, gestureState) => end(gestureState),
         onPanResponderTerminate: (evt, gestureState) => end(gestureState),
         onShouldBlockNativeResponder: (evt, gestureState) => true,


### PR DESCRIPTION
When being dragged, the slider would give up control of the event to any other parent listener that requested to handle the event, making it impossible to place it inside a scrollView or any other pan responder.